### PR TITLE
Updated "How to configure sandbox environment"

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,9 @@ api.listLocations().then(function(data) {
 ### How to configure sandbox environment
 ```javascript
 var SquareConnect = require('square-connect');
-var client = SquareConnect.ApiClient.instance;
+var defaultClient = SquareConnect.ApiClient.instance;
 // Set sandbox url
-client.basePath = 'https://connect.squareupsandbox.com';
+defaultClient.basePath = 'https://connect.squareupsandbox.com';
 // Configure OAuth2 access token for authorization: oauth2
 var oauth2 = defaultClient.authentications['oauth2'];
 // Set sandbox access token


### PR DESCRIPTION
I renamed the client variable to defaultClient in the "How to configure sandbox environment" code sample to keep consistency with the name given to the SquareConnect.ApiClient.instance in the first "Getting Started" code sample. Because in my case, I copied and pasted the first example and then just copied the line that sets the basePath, and because the naming is different, my code was failing. Hopefully, this fix in the documentation will allow distracted copy-pasters to move along seamlessly.